### PR TITLE
Fix for interfacied-Fq* in bls12.

### DIFF
--- a/bls12_381.go
+++ b/bls12_381.go
@@ -63,7 +63,7 @@ func (g1Point *bls12Point1) Mul(scalar *big.Int) Point1 {
 func (g1Point *bls12Point1) ToAffineCoords() (x, y *big.Int) {
 	g1Point.point.Normalize()
 	blsx, blsy, _ := g1Point.point.GetXYZ()
-	return blsx.ToInt(), blsy.ToInt()
+	return blsx.ToInt()[0], blsy.ToInt()[0]
 }
 
 func (g1Point *bls12Point1) Pair(g2Point Point2) (PointT, bool) {
@@ -153,7 +153,8 @@ func (pt bls12PointT) Mul(scalar *big.Int) PointT {
 }
 
 func (curve *bls12Curve) MakeG1Point(x, y *big.Int) (Point1, bool) {
-	pt := new(bls12.G1).SetXY(new(bls12.Fq).FromInt(x), new(bls12.Fq).FromInt(y))
+	pt := new(bls12.G1)
+	pt.SetXY(bls12.FqFromInt(x), bls12.FqFromInt(y))
 	// TODO need to add method to check if the point is on the curve whenever this is called.
 	// In the other library, this was already checked
 	return &bls12Point1{pt}, true
@@ -187,11 +188,11 @@ func (curve *bls12Curve) UnmarshalGT(data []byte) (PointT, bool) {
 }
 
 func (curve *bls12Curve) GetG1() Point1 {
-	return &bls12Point1{new(bls12.G1).SetOne()}
+	return &bls12Point1{bls12.G1One()}
 }
 
 func (curve *bls12Curve) GetG2() Point2 {
-	return &bls12Point2{new(bls12.G2).SetOne()}
+	return &bls12Point2{bls12.G2One()}
 }
 
 func (curve *bls12Curve) GetGT() PointT {
@@ -215,9 +216,8 @@ func (curve *bls12Curve) getG1Cofactor() *big.Int {
 }
 
 func (curve *bls12Curve) g1XToYSquared(x *big.Int) *big.Int {
-	pt := new(bls12.G1).SetXY(new(bls12.Fq).FromInt(x), new(bls12.Fq).FromInt(zero))
-	y := pt.Y2FromX()
-	return (&y).ToInt()
+	y := bls12.FqFromInt(x).Y2FromX(nil)
+	return y.ToInt()[0]
 }
 
 func (curve *bls12Curve) getG1Order() *big.Int {

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -31,7 +31,7 @@ var Bls12 = &bls12Curve{}
 func (g1Point *bls12Point1) Add(otherPoint1 Point1) (Point1, bool) {
 	g1Copy, _ := g1Point.Copy().(*bls12Point1)
 	if other, ok := (otherPoint1).(*bls12Point1); ok {
-		sum := g1Copy.point.Add(other.point)
+		sum := g1Copy.point.Add(other.point).(*bls12.G1)
 		ret := &bls12Point1{sum}
 		return ret, true
 	}
@@ -39,7 +39,7 @@ func (g1Point *bls12Point1) Add(otherPoint1 Point1) (Point1, bool) {
 }
 
 func (pt *bls12Point1) Copy() Point1 {
-	result := bls12Point1{pt.point.Copy()}
+	result := bls12Point1{pt.point.Copy().(*bls12.G1)}
 	return &result
 }
 
@@ -78,7 +78,7 @@ func (g1Point *bls12Point1) Pair(g2Point Point2) (PointT, bool) {
 func (pt *bls12Point2) Add(otherPt Point2) (Point2, bool) {
 	copy, _ := pt.Copy().(*bls12Point2)
 	if other, ok := (otherPt).(*bls12Point2); ok {
-		sum := copy.point.Add(other.point)
+		sum := copy.point.Add(other.point).(*bls12.G2)
 		ret := &bls12Point2{sum}
 		return ret, true
 	}
@@ -86,7 +86,7 @@ func (pt *bls12Point2) Add(otherPt Point2) (Point2, bool) {
 }
 
 func (pt *bls12Point2) Copy() Point2 {
-	result := bls12Point2{pt.point.Copy()}
+	result := bls12Point2{pt.point.Copy().(*bls12.G2)}
 	return &result
 }
 


### PR DESCRIPTION
Fq/Fq2 (and soon to be Fq12 for gt) is now abstracted to common interface https://github.com/dis2/bls12/blob/master/field.go

This presents some quirks in regards to things like FromInt/ToInt (which now operate on vectors of ints). SetOne/SetZero now fit an interface for marshalling, and thus can't return self for chaining. Use G1One() etc.