### PR TITLE
Bls12 and Fouque Tibouchi hashing

### DIFF
--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -79,6 +79,10 @@ func (g1Point *altbn128Point1) Marshal() []byte {
 	return xBytes
 }
 
+func (g1Point *altbn128Point1) MarshalUncompressed() []byte {
+	return g1Point.point.Marshal()
+}
+
 func pad32Bytes(xBytes []byte) []byte {
 	if len(xBytes) < 32 {
 		offset := 32 - len(xBytes)
@@ -176,6 +180,10 @@ func (g2Point *altbn128Point2) Marshal() []byte {
 	return xBytes
 }
 
+func (g2Point *altbn128Point2) MarshalUncompressed() []byte {
+	return g2Point.point.Marshal()
+}
+
 func (g2Point *altbn128Point2) Mul(scalar *big.Int) Point2 {
 	prod := new(bn256.G2).ScalarMult(g2Point.point, scalar)
 	ret := &altbn128Point2{prod}
@@ -247,6 +255,7 @@ func (curve *altbn128) UnmarshalG1(data []byte) (Point1, bool) {
 		// Underlying library already checks that y is on the curve, thus isQuadRes isn't checked here
 		y = calcQuadRes(y, altbnG1Q)
 		doubleY := new(big.Int).Mul(y, two)
+		// TODO switch this to use the parity method
 		cmpRes := doubleY.Cmp(altbnG1Q)
 		if ySgn && cmpRes == -1 {
 			y.Sub(altbnG1Q, y)
@@ -329,6 +338,10 @@ func (curve *altbn128) getG1Q() *big.Int {
 	return altbnG1Q
 }
 
+func (curve *altbn128) getG1QDivTwo() *big.Int {
+	return altbnG1QDiv2
+}
+
 func (curve *altbn128) getG1Order() *big.Int {
 	return altbnG1Order
 }
@@ -370,6 +383,7 @@ func (curve *altbn128) getFTHashParams() (*big.Int, *big.Int) {
 //curve specific constants
 var altbnG1B = big.NewInt(3)
 var altbnG1Q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
+var altbnG1QDiv2 = new(big.Int).Div(altbnG1Q, two)
 
 var altbnG2BRe, _ = new(big.Int).SetString("19485874751759354771024239261021720505790618469301721065564631296452457478373", 10)
 var altbnG2BIm, _ = new(big.Int).SetString("266929791119991161246907387137283842545076965332900288569378510910307636690", 10)

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -359,6 +359,10 @@ func (curve *altbn128) GetGT() PointT {
 	return altbnGT
 }
 
+func (curve *altbn128) getG1Cofactor() *big.Int {
+	return one
+}
+
 //curve specific constants
 var altbnG1B = big.NewInt(3)
 var altbnG1Q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
@@ -384,7 +388,7 @@ var altbnG1Order, _ = new(big.Int).SetString("2188824287183927522224640574525727
 // AltbnSha3 Hashes a message to a point on Altbn128 using SHA3 and try and increment
 // The return value is the x,y affine coordinate pair.
 func AltbnSha3(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash64(message, sha3.Sum512, Altbn128)
+	p1, p2 = tryAndIncrement64(message, sha3.Sum512, Altbn128)
 	return
 }
 
@@ -392,21 +396,21 @@ func AltbnSha3(message []byte) (p1, p2 *big.Int) {
 // Keccak3 is only for compatability with Ethereum hashing.
 // The return value is the x,y affine coordinate pair.
 func AltbnKeccak3(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash32(message, EthereumSum256, Altbn128)
+	p1, p2 = tryAndIncrementEvm(message, EthereumSum256, Altbn128)
 	return
 }
 
 // AltbnBlake2b Hashes a message to a point on Altbn128 using Blake2b and try and increment
 // The return value is the x,y affine coordinate pair.
 func AltbnBlake2b(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash64(message, blake2b.Sum512, Altbn128)
+	p1, p2 = tryAndIncrement64(message, blake2b.Sum512, Altbn128)
 	return
 }
 
 // AltbnKang12 Hashes a message to a point on Altbn128 using Blake2b and try and increment
 // The return value is the x,y affine coordinate pair.
 func AltbnKang12(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash64(message, kang12_64, Altbn128)
+	p1, p2 = tryAndIncrement64(message, kang12_64, Altbn128)
 	return
 }
 

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -426,13 +426,6 @@ func AltbnBlake2b(message []byte) (p1, p2 *big.Int) {
 	return
 }
 
-// AltbnKang12 Hashes a message to a point on Altbn128 using Blake2b and try and increment
-// The return value is the x,y affine coordinate pair.
-func AltbnKang12(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = tryAndIncrement64(message, kang12_64, Altbn128)
-	return
-}
-
 // HashToG1 Hashes a message to a point on Altbn128 using Keccak3 and try and increment
 // This is for compatability with Ethereum hashing.
 // The return value is the altbn_128 library's internel representation for points.

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -33,7 +33,8 @@ type altbn128PointT struct {
 var Altbn128 = &altbn128{}
 
 // MakeG1Point copies points into []byte and unmarshals to get around curvePoint not being exported
-func (curve *altbn128) MakeG1Point(x, y *big.Int) (Point1, bool) {
+// Note that check does nothing here, because the upstream library checks that the point is on the curve.
+func (curve *altbn128) MakeG1Point(x, y *big.Int, check bool) (Point1, bool) {
 	xBytes, yBytes := x.Bytes(), y.Bytes()
 	ret := make([]byte, 64)
 	copy(ret[32-len(xBytes):], xBytes)
@@ -249,7 +250,7 @@ func (curve *altbn128) UnmarshalG1(data []byte) (Point1, bool) {
 		}
 		x := new(big.Int).SetBytes(data)
 		if x.Cmp(zero) == 0 {
-			return Altbn128.MakeG1Point(zero, zero)
+			return Altbn128.MakeG1Point(zero, zero, false)
 		}
 		y := Altbn128.g1XToYSquared(x)
 		// Underlying library already checks that y is on the curve, thus isQuadRes isn't checked here
@@ -262,7 +263,7 @@ func (curve *altbn128) UnmarshalG1(data []byte) (Point1, bool) {
 		} else if !ySgn && cmpRes == 1 {
 			y.Sub(altbnG1Q, y)
 		}
-		return Altbn128.MakeG1Point(x, y)
+		return Altbn128.MakeG1Point(x, y, true)
 	}
 	return nil, false
 }
@@ -437,7 +438,7 @@ func AltbnKang12(message []byte) (p1, p2 *big.Int) {
 // The return value is the altbn_128 library's internel representation for points.
 func (curve *altbn128) HashToG1(message []byte) Point1 {
 	x, y := AltbnKeccak3(message)
-	p, _ := curve.MakeG1Point(x, y)
+	p, _ := curve.MakeG1Point(x, y, false)
 	return p
 }
 

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -363,6 +363,10 @@ func (curve *altbn128) getG1Cofactor() *big.Int {
 	return one
 }
 
+func (curve *altbn128) getFTHashParams() (*big.Int, *big.Int) {
+	return altbnSqrtn3, altbnZ
+}
+
 //curve specific constants
 var altbnG1B = big.NewInt(3)
 var altbnG1Q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -32,19 +32,6 @@ func TestAltbnHashToCurve(t *testing.T) {
 	}
 }
 
-// func TestBls12Hashing(t *testing.T) {
-// 	// Tests consistency
-// 	N := 10
-// 	msgs := make([][]byte, N)
-// 	for i := 0; i < N; i++ {
-// 		msgs[i] = make([]byte, N)
-// 		_, _ = rand.Read(msgs[i])
-// 		testHashConsistency(Bls12Sha3, "bls12 sha3 hash", msgs[i], t)
-// 		testHashConsistency(Bls12Kang12, "bls12 kang12 hash", msgs[i], t)
-// 		testHashConsistency(Bls12Blake2b, "bls12 blake2b hash", msgs[i], t)
-// 	}
-// }
-
 func testHashConsistency(hashFunc func(message []byte) (p1, p2 *big.Int), hashname string, msg []byte, t *testing.T) {
 	x1, y1 := hashFunc(msg)
 	x2, y2 := hashFunc(msg)

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -54,12 +54,13 @@ func testHashConsistency(hashFunc func(message []byte) (p1, p2 *big.Int), hashna
 func TestEthereumHash(t *testing.T) {
 	curve := Altbn128
 	// Tests Altbn hash to curve against known solidity test case.
-	a := []byte{116, 101, 115, 116}
-	x, y := AltbnKeccak3(a)
-	expX, _ := new(big.Int).SetString("634489172570043803084693618096875920319784881922983678883461805150451460743", 10)
-	expY, _ := new(big.Int).SetString("15164142362807052582232776116457640322025300091343369508144366426999358332749", 10)
+	a, _ := new(big.Int).SetString("9121282642809701931333593728297233225556711250127745709186816755779879923737", 10)
+	aBytes := a.Bytes()
+	x, y := AltbnKeccak3(aBytes)
+	expX, _ := new(big.Int).SetString("11423386531623885114587219621463106117140760157404497425836076043015227528156", 10)
+	expY, _ := new(big.Int).SetString("20262289731964024720969923714809935701428881933342918937283877214228227624643", 10)
 	assert.True(t, x.Cmp(expX) == 0 && y.Cmp(expY) == 0, "Hash does not match known Ethereum Output")
-	pt := curve.HashToG1(a)
+	pt := curve.HashToG1(aBytes)
 	x2, y2 := pt.ToAffineCoords()
 	assert.True(t, x.Cmp(x2) == 0 && y.Cmp(y2) == 0, "Conversion of point to coordinates is not working")
 
@@ -223,51 +224,53 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func TestKnownCases(t *testing.T) {
-	curve := Altbn128
-	N := 3
-	msgs := make([][]byte, N)
-	msg1 := []byte{65, 20, 86, 143, 250}
-	msg2 := []byte{157, 76, 30, 64, 128}
-	msg3 := []byte{202, 255, 227, 59, 238}
-	sk1, _ := new(big.Int).SetString("7830752896741750908830464020410322281763657818307273013205711220156049734883", 10)
-	sk2, _ := new(big.Int).SetString("10065703961787583059826108098259128135713944641698809475150397710106034167549", 10)
-	sk3, _ := new(big.Int).SetString("17145080297596291172729378766677038070724014074212589728874454474449054012678", 10)
-
-	pubkeys := make([]Point2, N)
-	vk1, vk2, vk3 := LoadPublicKey(curve, sk1), LoadPublicKey(curve, sk2), LoadPublicKey(curve, sk3)
-	msgs[0], msgs[1], msgs[2] = msg1, msg2, msg3
-	pubkeys[0], pubkeys[1], pubkeys[2] = vk1, vk2, vk3
-
-	sigGen1 := Sign(curve, sk1, msgs[0])
-	sigGen2 := Sign(curve, sk2, msgs[1])
-	sigGen3 := Sign(curve, sk3, msgs[2])
-	sigVal1_1, _ := new(big.Int).SetString("21637350149051642305293442272499488026428127697128429631193536777535027009518", 10)
-	sigVal1_2, _ := new(big.Int).SetString("149479762519169687769683150632580363857094522511606512652585818657412262489", 10)
-	sigVal2_1, _ := new(big.Int).SetString("14834848655731874780751719195269704123719987185153910215596714529658047741046", 10)
-	sigVal2_2, _ := new(big.Int).SetString("5847895190688397897156144807293187828750812390735163763226617490736304595451", 10)
-	sigVal3_1, _ := new(big.Int).SetString("21239057713889019692075876723610689006006025737755828182426488764514117409847", 10)
-	sigVal3_2, _ := new(big.Int).SetString("11967902298809667109716532536825395835657143208987520118971083760489593281874", 10)
-	sigChk1, _ := curve.MakeG1Point(sigVal1_1, sigVal1_2)
-	sigChk2, _ := curve.MakeG1Point(sigVal2_1, sigVal2_2)
-	sigChk3, _ := curve.MakeG1Point(sigVal3_1, sigVal3_2)
-
-	assert.False(t, (!sigChk1.Equals(sigGen1) || !sigChk2.Equals(sigGen2) || !sigChk3.Equals(sigGen3)),
-		"Recreating message signatures from known test cases failed")
-
-	sigs := make([]Point1, N)
-	sigs[0], sigs[1], sigs[2] = sigGen1, sigGen2, sigGen3
-
-	aggSig1, _ := new(big.Int).SetString("12682380538491839124790562586247816360937861029087546329767912056050859037239", 10)
-	aggSig2, _ := new(big.Int).SetString("5755139208159515629159661524903000057840676877654799839167369795924360592246", 10)
-	aggSigChk, _ := curve.MakeG1Point(aggSig1, aggSig2)
-
-	aggSig := AggregateG1(sigs)
-	assert.True(t, aggSigChk.Equals(aggSig),
-		"Aggregate Point1 does not match the known test case.")
-	assert.True(t, VerifyAggregateSignature(curve, aggSig, pubkeys, msgs, false),
-		"Aggregate Point1 verification failed")
-}
+// This is commented out because I just changed the hash implementation, so consistency
+// is supposed to be broken with past implementations.
+// func TestKnownCases(t *testing.T) {
+// 	curve := Altbn128
+// 	N := 3
+// 	msgs := make([][]byte, N)
+// 	msg1 := []byte{65, 20, 86, 143, 250}
+// 	msg2 := []byte{157, 76, 30, 64, 128}
+// 	msg3 := []byte{202, 255, 227, 59, 238}
+// 	sk1, _ := new(big.Int).SetString("7830752896741750908830464020410322281763657818307273013205711220156049734883", 10)
+// 	sk2, _ := new(big.Int).SetString("10065703961787583059826108098259128135713944641698809475150397710106034167549", 10)
+// 	sk3, _ := new(big.Int).SetString("17145080297596291172729378766677038070724014074212589728874454474449054012678", 10)
+//
+// 	pubkeys := make([]Point2, N)
+// 	vk1, vk2, vk3 := LoadPublicKey(curve, sk1), LoadPublicKey(curve, sk2), LoadPublicKey(curve, sk3)
+// 	msgs[0], msgs[1], msgs[2] = msg1, msg2, msg3
+// 	pubkeys[0], pubkeys[1], pubkeys[2] = vk1, vk2, vk3
+//
+// 	sigGen1 := Sign(curve, sk1, msgs[0])
+// 	sigGen2 := Sign(curve, sk2, msgs[1])
+// 	sigGen3 := Sign(curve, sk3, msgs[2])
+// 	sigVal1_1, _ := new(big.Int).SetString("21637350149051642305293442272499488026428127697128429631193536777535027009518", 10)
+// 	sigVal1_2, _ := new(big.Int).SetString("149479762519169687769683150632580363857094522511606512652585818657412262489", 10)
+// 	sigVal2_1, _ := new(big.Int).SetString("14834848655731874780751719195269704123719987185153910215596714529658047741046", 10)
+// 	sigVal2_2, _ := new(big.Int).SetString("5847895190688397897156144807293187828750812390735163763226617490736304595451", 10)
+// 	sigVal3_1, _ := new(big.Int).SetString("21239057713889019692075876723610689006006025737755828182426488764514117409847", 10)
+// 	sigVal3_2, _ := new(big.Int).SetString("11967902298809667109716532536825395835657143208987520118971083760489593281874", 10)
+// 	sigChk1, _ := curve.MakeG1Point(sigVal1_1, sigVal1_2)
+// 	sigChk2, _ := curve.MakeG1Point(sigVal2_1, sigVal2_2)
+// 	sigChk3, _ := curve.MakeG1Point(sigVal3_1, sigVal3_2)
+//
+// 	assert.False(t, (!sigChk1.Equals(sigGen1) || !sigChk2.Equals(sigGen2) || !sigChk3.Equals(sigGen3)),
+// 		"Recreating message signatures from known test cases failed")
+//
+// 	sigs := make([]Point1, N)
+// 	sigs[0], sigs[1], sigs[2] = sigGen1, sigGen2, sigGen3
+//
+// 	aggSig1, _ := new(big.Int).SetString("12682380538491839124790562586247816360937861029087546329767912056050859037239", 10)
+// 	aggSig2, _ := new(big.Int).SetString("5755139208159515629159661524903000057840676877654799839167369795924360592246", 10)
+// 	aggSigChk, _ := curve.MakeG1Point(aggSig1, aggSig2)
+//
+// 	aggSig := AggregateG1(sigs)
+// 	assert.True(t, aggSigChk.Equals(aggSig),
+// 		"Aggregate Point1 does not match the known test case.")
+// 	assert.True(t, VerifyAggregateSignature(curve, aggSig, pubkeys, msgs, false),
+// 		"Aggregate Point1 verification failed")
+// }
 
 func BenchmarkKeygen(b *testing.B) {
 	b.ResetTimer()

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -14,30 +14,6 @@ import (
 
 var curves = []CurveSystem{Altbn128, Bls12}
 
-func TestAltbnHashToCurve(t *testing.T) {
-	curve := Altbn128
-	N := 10
-	msgs := make([][]byte, N)
-	for i := 0; i < N; i++ {
-		msgs[i] = make([]byte, N)
-		_, _ = rand.Read(msgs[i])
-
-		testHashConsistency(AltbnSha3, "altbn sha3 hash", msgs[i], t)
-		testHashConsistency(AltbnKang12, "altbn kang12 hash", msgs[i], t)
-		testHashConsistency(AltbnBlake2b, "altbn blake2b hash", msgs[i], t)
-
-		p1 := curve.HashToG1(msgs[i])
-		p2 := curve.HashToG1(msgs[i])
-		assert.True(t, p1.Equals(p2), "inconsistent results in Altbn HashToCurve")
-	}
-}
-
-func testHashConsistency(hashFunc func(message []byte) (p1, p2 *big.Int), hashname string, msg []byte, t *testing.T) {
-	x1, y1 := hashFunc(msg)
-	x2, y2 := hashFunc(msg)
-	assert.True(t, x1.Cmp(x2) == 0 && y1.Cmp(y2) == 0, "inconsistent results in "+hashname)
-}
-
 func TestEthereumHash(t *testing.T) {
 	curve := Altbn128
 	// Tests Altbn hash to curve against known solidity test case.

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var curves = []CurveSystem{Altbn128}
+var curves = []CurveSystem{Altbn128, Bls12}
 
 func TestAltbnHashToCurve(t *testing.T) {
 	curve := Altbn128

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -63,7 +63,7 @@ func (g1Point *bls12Point1) Mul(scalar *big.Int) Point1 {
 func (g1Point *bls12Point1) ToAffineCoords() (x, y *big.Int) {
 	g1Point.point.Normalize()
 	blsx, blsy, _ := g1Point.point.GetXYZ()
-	return blsx.ToInt(), blsy.ToInt()
+	return blsx.ToInt()[0], blsy.ToInt()[0]
 }
 
 func (g1Point *bls12Point1) Pair(g2Point Point2) (PointT, bool) {
@@ -153,7 +153,8 @@ func (pt bls12PointT) Mul(scalar *big.Int) PointT {
 }
 
 func (curve *bls12Curve) MakeG1Point(x, y *big.Int) (Point1, bool) {
-	pt := new(bls12.G1).SetXY(new(bls12.Fq).FromInt(x), new(bls12.Fq).FromInt(y))
+	pt := new(bls12.G1)
+	pt.SetXY(bls12.FqFromInt(x), bls12.FqFromInt(y))
 	// TODO need to add method to check if the point is on the curve whenever this is called.
 	// In the other library, this was already checked
 	return &bls12Point1{pt}, true
@@ -187,11 +188,11 @@ func (curve *bls12Curve) UnmarshalGT(data []byte) (PointT, bool) {
 }
 
 func (curve *bls12Curve) GetG1() Point1 {
-	return &bls12Point1{new(bls12.G1).SetOne()}
+	return &bls12Point1{bls12.G1One()}
 }
 
 func (curve *bls12Curve) GetG2() Point2 {
-	return &bls12Point2{new(bls12.G2).SetOne()}
+	return &bls12Point2{bls12.G2One()}
 }
 
 func (curve *bls12Curve) GetGT() PointT {
@@ -215,9 +216,8 @@ func (curve *bls12Curve) getG1Cofactor() *big.Int {
 }
 
 func (curve *bls12Curve) g1XToYSquared(x *big.Int) *big.Int {
-	pt := new(bls12.G1).SetXY(new(bls12.Fq).FromInt(x), new(bls12.Fq).FromInt(zero))
-	y := pt.Y2FromX()
-	return (&y).ToInt()
+	y := bls12.FqFromInt(x).Y2FromX(nil)
+	return y.ToInt()[0]
 }
 
 func (curve *bls12Curve) getG1Order() *big.Int {

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -31,7 +31,7 @@ var Bls12 = &bls12Curve{}
 func (g1Point *bls12Point1) Add(otherPoint1 Point1) (Point1, bool) {
 	g1Copy, _ := g1Point.Copy().(*bls12Point1)
 	if other, ok := (otherPoint1).(*bls12Point1); ok {
-		sum := g1Copy.point.Add(other.point)
+		sum := g1Copy.point.Add(other.point).(*bls12.G1)
 		ret := &bls12Point1{sum}
 		return ret, true
 	}
@@ -39,7 +39,7 @@ func (g1Point *bls12Point1) Add(otherPoint1 Point1) (Point1, bool) {
 }
 
 func (pt *bls12Point1) Copy() Point1 {
-	result := bls12Point1{pt.point.Copy()}
+	result := bls12Point1{pt.point.Copy().(*bls12.G1)}
 	return &result
 }
 
@@ -78,7 +78,7 @@ func (g1Point *bls12Point1) Pair(g2Point Point2) (PointT, bool) {
 func (pt *bls12Point2) Add(otherPt Point2) (Point2, bool) {
 	copy, _ := pt.Copy().(*bls12Point2)
 	if other, ok := (otherPt).(*bls12Point2); ok {
-		sum := copy.point.Add(other.point)
+		sum := copy.point.Add(other.point).(*bls12.G2)
 		ret := &bls12Point2{sum}
 		return ret, true
 	}
@@ -86,7 +86,7 @@ func (pt *bls12Point2) Add(otherPt Point2) (Point2, bool) {
 }
 
 func (pt *bls12Point2) Copy() Point2 {
-	result := bls12Point2{pt.point.Copy()}
+	result := bls12Point2{pt.point.Copy().(*bls12.G2)}
 	return &result
 }
 

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -5,20 +5,257 @@ package bgls
 
 import (
 	"math/big"
+
+	"github.com/dchest/blake2b"
+	"github.com/dis2/bls12"
 )
+
+type bls12Curve struct {
+}
+
+type bls12Point1 struct {
+	point *bls12.G1
+}
+
+type bls12Point2 struct {
+	point *bls12.G2
+}
+
+type bls12PointT struct {
+	point *bls12.GT
+}
+
+// Bls12 is the instance for the bls12 curve, with all of its functions.
+var Bls12 = &bls12Curve{}
+
+func (g1Point *bls12Point1) Add(otherPoint1 Point1) (Point1, bool) {
+	g1Copy, _ := g1Point.Copy().(*bls12Point1)
+	if other, ok := (otherPoint1).(*bls12Point1); ok {
+		sum := g1Copy.point.Add(other.point)
+		ret := &bls12Point1{sum}
+		return ret, true
+	}
+	return nil, false
+}
+
+func (pt *bls12Point1) Copy() Point1 {
+	result := bls12Point1{pt.point.Copy()}
+	return &result
+}
+
+func (pt *bls12Point1) Equals(otherPoint1 Point1) bool {
+	if other, ok := (otherPoint1).(*bls12Point1); ok {
+		return pt.point.Equal(other.point)
+	}
+	return false
+}
+
+func (g1Point *bls12Point1) Marshal() []byte {
+	return g1Point.point.Marshal()
+}
+
+func (g1Point *bls12Point1) Mul(scalar *big.Int) Point1 {
+	prod, _ := g1Point.Copy().(*bls12Point1)
+	prod.point.ScalarMult(new(bls12.Scalar).FromInt(scalar))
+	return prod
+}
+
+func (g1Point *bls12Point1) ToAffineCoords() (x, y *big.Int) {
+	g1Point.point.Normalize()
+	blsx, blsy, _ := g1Point.point.GetXYZ()
+	return blsx.ToInt(), blsy.ToInt()
+}
+
+func (g1Point *bls12Point1) Pair(g2Point Point2) (PointT, bool) {
+	if other, ok := (g2Point).(*bls12Point2); ok {
+		p3 := new(bls12.GT).Pair(g1Point.point, other.point)
+		ret := bls12PointT{p3}
+		return ret, true
+	}
+	return nil, false
+}
+
+func (pt *bls12Point2) Add(otherPt Point2) (Point2, bool) {
+	copy, _ := pt.Copy().(*bls12Point2)
+	if other, ok := (otherPt).(*bls12Point2); ok {
+		sum := copy.point.Add(other.point)
+		ret := &bls12Point2{sum}
+		return ret, true
+	}
+	return nil, false
+}
+
+func (pt *bls12Point2) Copy() Point2 {
+	result := bls12Point2{pt.point.Copy()}
+	return &result
+}
+
+func (pt *bls12Point2) Equals(otherPt Point2) bool {
+	if other, ok := (otherPt).(*bls12Point2); ok {
+		return pt.point.Equal(other.point)
+	}
+	return false
+}
+
+func (pt *bls12Point2) Marshal() []byte {
+	return pt.point.Marshal()
+}
+
+func (pt *bls12Point2) Mul(scalar *big.Int) Point2 {
+	prod, _ := pt.Copy().(*bls12Point2)
+	prod.point.ScalarMult(new(bls12.Scalar).FromInt(scalar))
+	return prod
+}
+
+func (pt *bls12Point2) ToAffineCoords() (xx, xy, yx, yy *big.Int) {
+	// TODO These constants definitely need to be adjusted
+	// Currently this is just implemented to satisfy the curve interface.
+	Bytestream := pt.point.Marshal()
+	xxBytes, xyBytes := Bytestream[:32], Bytestream[32:64]
+	yxBytes, yyBytes := Bytestream[64:96], Bytestream[96:128]
+	xx = new(big.Int).SetBytes(xxBytes)
+	xy = new(big.Int).SetBytes(xyBytes)
+	yx = new(big.Int).SetBytes(yxBytes)
+	yy = new(big.Int).SetBytes(yyBytes)
+	return
+}
+
+func (pt bls12PointT) Add(otherPt PointT) (PointT, bool) {
+	copy, _ := pt.Copy().(bls12PointT)
+	if other, ok := (otherPt).(bls12PointT); ok {
+		sum := copy.point.Add(other.point)
+		ret := bls12PointT{sum}
+		return ret, true
+	}
+	return nil, false
+}
+
+func (pt bls12PointT) Copy() PointT {
+	result := bls12PointT{pt.point.Copy()}
+	return result
+}
+
+func (pt bls12PointT) Equals(otherPt PointT) bool {
+	if other, ok := (otherPt).(bls12PointT); ok {
+		return pt.point.Equal(other.point)
+	}
+	return false
+}
+
+func (pt bls12PointT) Marshal() []byte {
+	return pt.point.Marshal()
+}
+
+func (pt bls12PointT) Mul(scalar *big.Int) PointT {
+	prod, _ := pt.Copy().(bls12PointT)
+	prod.point.ScalarMult(new(bls12.Scalar).FromInt(scalar))
+	return prod
+}
+
+func (curve *bls12Curve) MakeG1Point(x, y *big.Int) (Point1, bool) {
+	pt := new(bls12.G1).SetXY(new(bls12.Fq).FromInt(x), new(bls12.Fq).FromInt(y))
+	// TODO need to add method to check if the point is on the curve whenever this is called.
+	// In the other library, this was already checked
+	return &bls12Point1{pt}, true
+}
+
+func (curve *bls12Curve) UnmarshalG1(data []byte) (Point1, bool) {
+	result := new(bls12.G1)
+	success := result.Unmarshal(data)
+	if success == nil {
+		return nil, false
+	}
+	return &bls12Point1{result}, true
+}
+
+func (curve *bls12Curve) UnmarshalG2(data []byte) (Point2, bool) {
+	result := new(bls12.G2)
+	success := result.Unmarshal(data)
+	if success == nil {
+		return nil, false
+	}
+	return &bls12Point2{result}, true
+}
+
+func (curve *bls12Curve) UnmarshalGT(data []byte) (PointT, bool) {
+	result := new(bls12.GT)
+	success := result.Unmarshal(data)
+	if success == nil {
+		return nil, false
+	}
+	return &bls12PointT{result}, true
+}
+
+func (curve *bls12Curve) GetG1() Point1 {
+	return &bls12Point1{new(bls12.G1).SetOne()}
+}
+
+func (curve *bls12Curve) GetG2() Point2 {
+	return &bls12Point2{new(bls12.G2).SetOne()}
+}
+
+func (curve *bls12Curve) GetGT() PointT {
+	return GT
+}
+
+func (curve *bls12Curve) getG1A() *big.Int {
+	return zero
+}
+
+func (curve *bls12Curve) getG1B() *big.Int {
+	return bls12B
+}
+
+func (curve *bls12Curve) getG1Q() *big.Int {
+	return bls12Q
+}
+
+func (curve *bls12Curve) getG1Cofactor() *big.Int {
+	return bls12Cofactor
+}
+
+func (curve *bls12Curve) g1XToYSquared(x *big.Int) *big.Int {
+	pt := new(bls12.G1).SetXY(new(bls12.Fq).FromInt(x), new(bls12.Fq).FromInt(zero))
+	y := pt.Y2FromX()
+	return (&y).ToInt()
+}
+
+func (curve *bls12Curve) getG1Order() *big.Int {
+	return bls12Order
+}
+
+func (curve *bls12Curve) getFTHashParams() (*big.Int, *big.Int) {
+	return bls12SqrtNeg3, bls12Z
+}
 
 var bls12Q, _ = new(big.Int).SetString("0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab", 0)
 var bls12X, _ = new(big.Int).SetString("-0xd201000000010000", 0)
 var bls12A, _ = new(big.Int).SetString("0", 10)
 var bls12B, _ = new(big.Int).SetString("4", 10)
-var bls12Cofactor = makeBls12Cofactor(bls12X)
 
-func makeBls12Cofactor(x *big.Int) *big.Int {
+//precomputed Z = (-1 + sqrt(-3))/2 in Fq
+var bls12Z, _ = new(big.Int).SetString("793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350", 10)
+
+//precomputed sqrt(-3) in Fq
+var bls12SqrtNeg3, _ = new(big.Int).SetString("1586958781458431025242759403266842894121773480562120986020912974854563298150952611241517463240701", 10)
+var bls12Cofactor = makeBlsCofactor(bls12X)
+var bls12Order, _ = new(big.Int).SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
+var GT, _ = Bls12.GetG1().Pair(Bls12.GetG2())
+
+func makeBlsCofactor(x *big.Int) *big.Int {
 	x.Mod(x, bls12Q)
 	x.Sub(x, one)
 	x.Exp(x, x, two)
 	x.Div(x, three)
 	return x
+}
+
+// This is currently a filler method so I can get the initial structure of bls12 committed.
+// This is going to be Foque Tibouchi hashing that is compatible with ebfull/pairings
+func (curve *bls12Curve) HashToG1(message []byte) Point1 {
+	x, y := tryAndIncrement64(message, blake2b.Sum512, Bls12)
+	p, _ := curve.MakeG1Point(x, y)
+	return p
 }
 
 // // Bls12Sha3 Hashes a message to a point on BLS12-381 using SHA3 and try and increment

--- a/bls12_test.go
+++ b/bls12_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2018 Authors
+// distributed under Apache 2.0 license
+
+package bgls
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestG1BlindingMatches(t *testing.T) {
+	N := 100
+	msgSize := 64
+	for i := 0; i < N; i++ {
+		msg := make([]byte, msgSize)
+		_, _ = rand.Read(msg)
+
+		p1 := Bls12.HashToG1(msg)
+		p2 := Bls12.HashToG1Blind(msg)
+		assert.True(t, p1.Equals(p2), "inconsistent results with BLS normal and blind hashing to G1")
+	}
+}
+
+// Commented out because I'm unsure of the format test vectors will eventually be in
+// func TestG1HashVectors(t *testing.T) {
+// 	// Says whether or not to generate test vectors
+// 	generate := false
+// 	if generate {
+// 		generateG1HashVectors()
+// 	}
+// }
+//
+// func generateG1HashVectors() {
+// 	N := 100
+// 	msgSize := 64
+// 	output := make([]byte, 0, N*(msgSize+96))
+// 	for i := 0; i < N; i++ {
+// 		msg := make([]byte, msgSize)
+// 		_, _ = rand.Read(msg)
+// 		x, y := Bls12.HashToG1(msg).ToAffineCoords()
+// 		xBytes := x.Bytes()
+// 		yBytes := y.Bytes()
+// 		coordinateBytes := make([]byte, 96)
+// 		// This ensures that there are leading zeroes
+// 		copy(coordinateBytes[48-len(xBytes):], xBytes)
+// 		copy(coordinateBytes[96-len(yBytes):], yBytes)
+// 		mutativeAppend(&output, msg)
+// 		mutativeAppend(&output, coordinateBytes)
+// 		// Newline
+// 		mutativeAppend(&output, []byte("\n"))
+// 	}
+// 	os.Remove("testcases/bls12G1Hash.txt")
+// 	ioutil.WriteFile("testcases/bls12G1Hash.txt", output, 0644)
+// }
+//
+// func mutativeAppend(s *[]byte, msg []byte) {
+// 	*s = append(*s, msg...)
+// }

--- a/curve.go
+++ b/curve.go
@@ -10,7 +10,7 @@ import (
 // CurveSystem is a set of parameters and functions for a pairing based cryptosystem
 // It has everything necessary to support all bgls functionality which we use.
 type CurveSystem interface {
-	MakeG1Point(*big.Int, *big.Int) (Point1, bool)
+	MakeG1Point(*big.Int, *big.Int, bool) (Point1, bool)
 	// MakeG2Point(*big.Int, *big.Int, *big.Int, *big.Int) (Point2, bool)
 	// MakeGTPoint(*big.Int, *big.Int) (PointT, bool)
 

--- a/curve.go
+++ b/curve.go
@@ -28,6 +28,7 @@ type CurveSystem interface {
 	HashToG1(message []byte) Point1
 
 	getG1Q() *big.Int
+	getG1QDivTwo() *big.Int
 	// getGTQ() *big.Int
 
 	getG1Cofactor() *big.Int
@@ -46,6 +47,7 @@ type Point1 interface {
 	Copy() Point1
 	Equals(Point1) bool
 	Marshal() []byte
+	MarshalUncompressed() []byte
 	Mul(*big.Int) Point1
 	Pair(Point2) (PointT, bool)
 	ToAffineCoords() (*big.Int, *big.Int)
@@ -57,6 +59,7 @@ type Point2 interface {
 	Copy() Point2
 	Equals(Point2) bool
 	Marshal() []byte
+	MarshalUncompressed() []byte
 	Mul(*big.Int) Point2
 	ToAffineCoords() (*big.Int, *big.Int, *big.Int, *big.Int)
 }

--- a/curve.go
+++ b/curve.go
@@ -34,7 +34,7 @@ type CurveSystem interface {
 
 	getG1A() *big.Int
 	getG1B() *big.Int
-	// Fouque-Tibouchi hash parameters
+	// Fouque-Tibouchi hash parameters, sqrt(-3), (-1 + sqrt(-3))/2 computed in F_q
 	getFTHashParams() (*big.Int, *big.Int)
 	getG1Order() *big.Int
 	g1XToYSquared(*big.Int) *big.Int

--- a/curve.go
+++ b/curve.go
@@ -34,6 +34,8 @@ type CurveSystem interface {
 
 	getG1A() *big.Int
 	getG1B() *big.Int
+	// Fouque-Tibouchi hash parameters
+	getFTHashParams() (*big.Int, *big.Int)
 	getG1Order() *big.Int
 	g1XToYSquared(*big.Int) *big.Int
 }

--- a/curve.go
+++ b/curve.go
@@ -30,6 +30,8 @@ type CurveSystem interface {
 	getG1Q() *big.Int
 	// getGTQ() *big.Int
 
+	getG1Cofactor() *big.Int
+
 	getG1A() *big.Int
 	getG1B() *big.Int
 	getG1Order() *big.Int

--- a/hash.go
+++ b/hash.go
@@ -87,7 +87,10 @@ func sortBigInts(b1 *big.Int, b2 *big.Int) (*big.Int, *big.Int) {
 
 // Shallue - van de Woestijne encoding
 // from "Indifferentiable Hashing to Barreto–Naehrig Curves"
-func sw(curve CurveSystem, t *big.Int, maskQuadRes bool) (Point1, bool) {
+func sw(curve CurveSystem, t *big.Int, blindQuadChar bool) (Point1, bool) {
+	if t == zero {
+		return curve.MakeG1Point(zero, zero)
+	} // TODO Add other case where t is undefined
 	var x [3]*big.Int
 
 	//w = sqrt(-3)*t / (1 + b + t^2)
@@ -96,7 +99,8 @@ func sw(curve CurveSystem, t *big.Int, maskQuadRes bool) (Point1, bool) {
 	b := curve.getG1B()
 	rootNeg3, neg1SubRootNeg3 := curve.getFTHashParams()
 	w.Exp(t, two, q)
-	w.Add(w.Add(w, one), b)
+	w.Add(w, one)
+	w.Add(w, b)
 	w.ModInverse(w, q)
 	w.Mul(w, t)
 	w.Mod(w, q)
@@ -126,14 +130,14 @@ func sw(curve CurveSystem, t *big.Int, maskQuadRes bool) (Point1, bool) {
 	x[2].Mod(x[2], q)
 
 	//i = first x[i] such that (x^3 + b) is square
-	i := (((chkPoint(x[0], q, b, maskQuadRes) - 1) * chkPoint(x[1], q, b, maskQuadRes)) + 3) % 3
+	i := (((chkPoint(x[0], q, b, blindQuadChar) - 1) * chkPoint(x[1], q, b, blindQuadChar)) + 3) % 3
 
 	//y = quadRes(t) * sqrt(x^3 + b)
 	yr := new(big.Int)
 	yr.Exp(x[i], three, q)
 	yr.Add(yr, b)
 	yr = calcQuadRes(yr, q)
-	yr.Mul(yr, big.NewInt(maskedQuadRes(t, q, maskQuadRes)))
+	yr.Mul(yr, big.NewInt(quadraticCharacter(t, q, blindQuadChar)))
 	yr.Mod(yr, q)
 
 	return curve.MakeG1Point(x[i], yr)
@@ -196,10 +200,12 @@ func randSquare(q *big.Int) *big.Int {
 	return r.Exp(r, two, q)
 }
 
-//masks x with a random square in Fq, to limit timing leakage
-func maskedQuadRes(k *big.Int, q *big.Int, mask bool) int64 {
+// If blind is true, this blinds k with a random square in Fq,
+// and then returns square root. This can be done to limit timing leakage.
+// This returns the quadratic character of k.
+func quadraticCharacter(k *big.Int, q *big.Int, blind bool) int64 {
 	r := k
-	if mask {
+	if blind {
 		r = randSquare(q)
 		r.Mul(r, k)
 		r.Mod(r, q)
@@ -216,7 +222,7 @@ func chkPoint(x *big.Int, q *big.Int, b *big.Int, mask bool) int64 {
 	x3pb := new(big.Int).Exp(x, three, q)
 	x3pb.Add(x3pb, b)
 	x3pb.Mod(x3pb, q)
-	return maskedQuadRes(x3pb, q, mask)
+	return quadraticCharacter(x3pb, q, mask)
 }
 
 // Implement Eulers Criterion

--- a/hash.go
+++ b/hash.go
@@ -6,8 +6,6 @@ package bgls
 import (
 	"crypto/rand"
 	"math/big"
-
-	"github.com/mimoo/GoKangarooTwelve/K12"
 )
 
 var zero = big.NewInt(0)
@@ -96,7 +94,6 @@ func fouqueTibouchiG1(curve CurveSystem, t *big.Int, blind bool) (Point1, bool) 
 
 // Shallue - van de Woestijne encoding
 // from "Indifferentiable Hashing to Barreto–Naehrig Curves"
-// TODO Don't calculate unneccessary x values in unblinded case.
 func sw(curve CurveSystem, t *big.Int, blind bool) (Point1, bool) {
 	var x [3]*big.Int
 	b := curve.getG1B()
@@ -268,16 +265,4 @@ func isQuadRes(a *big.Int, q *big.Int) bool {
 		return true
 	}
 	return false
-}
-
-// 64 byte kangaroo twelve hash
-func kang12_64(messageDat []byte) [64]byte {
-	inputByte := make([]byte, 1)
-	hashFunc := K12.NewK12(inputByte)
-	hashFunc.Write(messageDat)
-	out := make([]byte, 64)
-	hashFunc.Read(out)
-	x := [64]byte{}
-	copy(x[:], out[:64])
-	return x
 }

--- a/hash.go
+++ b/hash.go
@@ -29,13 +29,13 @@ func kang12_64(messageDat []byte) [64]byte {
 
 // 64 byte hash
 func tryAndIncrement64(message []byte, hashfunc func(message []byte) [64]byte, curve CurveSystem) (px, py *big.Int) {
-	c := 0
+	counter := []byte{byte(0)}
 	px = new(big.Int)
 	py = new(big.Int)
 	q := curve.getG1Q()
 	for {
-		h := hashfunc(append(message, byte(c)))
-		c++
+		h := hashfunc(append(counter, message...))
+		counter[0]++
 		px.SetBytes(h[:48])
 		px.Mod(px, q)
 		ySqr := curve.g1XToYSquared(px)
@@ -71,13 +71,13 @@ func sortBigInts(b1 *big.Int, b2 *big.Int) (*big.Int, *big.Int) {
 // Try and Increment hashing that is meant to comply with the standards we are using in the solidity contract.
 // This is not recommended for use anywhere else.
 func tryAndIncrementEvm(message []byte, hashfunc func(message []byte) [32]byte, curve CurveSystem) (px, py *big.Int) {
-	c := 0
+	counter := []byte{byte(0)}
 	px = new(big.Int)
 	py = new(big.Int)
 	q := curve.getG1Q()
 	for {
-		h := hashfunc(append(message, byte(c)))
-		c++
+		h := hashfunc(append(counter, message...))
+		counter[0]++
 		px.SetBytes(h[:32])
 		px.Mod(px, q)
 		ySqr := curve.g1XToYSquared(px)
@@ -85,7 +85,8 @@ func tryAndIncrementEvm(message []byte, hashfunc func(message []byte) [32]byte, 
 		rootSqr := new(big.Int).Exp(root, two, q)
 		if rootSqr.Cmp(ySqr) == 0 {
 			py = root
-			signY := hashfunc(append(message, byte(255)))[31] % 2
+			counter[0] = byte(255)
+			signY := hashfunc(append(counter, message...))[31] % 2
 			if signY == 1 {
 				py.Sub(q, py)
 			}


### PR DESCRIPTION
This PR adds support for dis2/bls12 , adds Fouque Tibouchi hashing for BLS12, and fixes the counter being placed incorrectly in a non-standard position in try and increment. Work is currently being done to make this hashing match the specification currently being created in ebfull/pairing. 